### PR TITLE
Fix formatting of logging options in compose file

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     logging:
       options:
         max-size: 1M
-        max-file: 10
+        max-file: "10"
     deploy:
       resources:
         limits:
@@ -65,7 +65,7 @@ services:
     logging:
       options:
         max-size: 1M
-        max-file: 10
+        max-file: "10"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Before this modification, `docker-compose` fails to create the containers, with an error like:
```
ERROR: for example_stream-enrich_1  Cannot create container for service stream-enrich: json: cannot unmarshal number into Go value of type string
```

See https://github.com/docker/compose/issues/4153