### PR TITLE
Added image for EmrEtlRunner

### DIFF
--- a/emr-etl-runner/README.md
+++ b/emr-etl-runner/README.md
@@ -7,10 +7,9 @@ This folder contains the Docker images for [the EmrEtlRunner][emretlrunner].
 This image is based on [the debian base image][debian-base-image] which leverages
 [the Java 8 Debian image][debian-image] due to a [JRuby bug][jruby-bug] still unsolved.
 
-The EmrEtlRunner uses [gosu][gosu], as a sudo replacement, to run the
-collector as the non-root `snowplow` user.
+The EmrEtlRunner uses [gosu][gosu], as a sudo replacement, to run as the non-root `snowplow` user.
 
-The container exposes the `/snowplow/config` volume to store the collector configuration. If this
+The container exposes the `/snowplow/config` volume to store the EmrEtlRunner configuration. If this
 folder is bind mounted then ownership will be changed to the `snowplow` user.
 
 ## Usage
@@ -36,7 +35,7 @@ Global options are:
     -v, --version                    Show version
 ```
 
-Alternatively, we can mount a configuration folder, publish port 80, and run the collector:
+Alternatively, we can mount a configuration folder and run EmrEtlRunner:
 
 ```bash
 $ docker run \
@@ -50,7 +49,7 @@ $ docker run \
 
 ## Copyright and license
 
-Snowplow::EmrEtlRunner is copyright 2012-2014 Snowplow Analytics Ltd.
+The EmrEtlRunner image is copyright 2018-2018 Snowplow Analytics Ltd.
 
 Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.

--- a/emr-etl-runner/README.md
+++ b/emr-etl-runner/README.md
@@ -1,0 +1,69 @@
+# EMR ETL Runner
+
+This folder contains the Docker images for [the EmrEtlRunner][emretlrunner].
+
+## Introduction
+
+This image is based on [the debian base image][debian-base-image] which leverages
+[the Java 8 Debian image][debian-image] due to a [JRuby bug][jruby-bug] still unsolved.
+
+The EmrEtlRunner uses [gosu][gosu], as a sudo replacement, to run the
+collector as the non-root `snowplow` user.
+
+The container exposes the `/snowplow/config` volume to store the collector configuration. If this
+folder is bind mounted then ownership will be changed to the `snowplow` user.
+
+## Usage
+
+Running the container without arguments will print out its usage:
+
+```bash
+$ VERSION=r109_lambaesis
+$ docker run snowplow-docker-registry.bintray.io/snowplow/emr-etl-runner:${VERSION}
+
+Usage snowplow-emr-etl-runner [options] [command [options]]
+
+Available commands are:
+run: Run the Snowplow pipeline on EMR
+generate emr-config: Generate a Dataflow Runner EMR config which can be used with dataflow-runner up
+generate emr-playbook: Generate a Dataflow Runner Playbook config which can be used with dataflow-runner run
+generate all: Generate both a Dataflow Runner EMR (as emr-config.json) and Playbook (as emr-playbook.json) configs
+lint resolver: Lint an Iglu resolver config to check if it is valid with respect to its schema
+lint enrichments: Lint enrichments to check if they are valid with respect to their schemas
+lint all: Lint both Iglu resolver config and enrichments to check if they are valid with respect to their schemas
+
+Global options are:
+    -v, --version                    Show version
+```
+
+Alternatively, we can mount a configuration folder, publish port 80, and run the collector:
+
+```bash
+$ docker run \
+  -d \
+  -v ${PWD}/config:/snowplow/config \
+  snowplow-docker-registry.bintray.io/snowplow/emr-etl-runner:${VERSION} \
+  --config /snowplow/config/stream_config.yml \
+  --resolver /snowplow/config/resolver.json \
+  --target /snowplow/config/targets
+```
+
+## Copyright and license
+
+Snowplow::EmrEtlRunner is copyright 2012-2014 Snowplow Analytics Ltd.
+
+Licensed under the [Apache License, Version 2.0][license] (the "License");
+you may not use this software except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+[emretlrunner]: https://github.com/snowplow/snowplow/tree/master/3-enrich/emr-etl-runner
+[debian-image]: https://github.com/docker-library/openjdk/blob/master/8-jre/slim/Dockerfile
+[debian-base-image]: https://github.com/snowplow/snowplow-docker/tree/develop/base-debian
+[jruby-bug]: https://discourse.snowplowanalytics.com/t/systemcallerror-unknown-error-unknown-error-0-home-ubuntu-netrc/452
+[gosu]: https://github.com/tianon/gosu
+[license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/emr-etl-runner/r109_lambaesis/Dockerfile
+++ b/emr-etl-runner/r109_lambaesis/Dockerfile
@@ -1,0 +1,24 @@
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
+
+# The version of stream enrich to download.
+ENV EMR_ETL_RUNNER_VERSION="r109_lambaesis"
+
+# The name of the archive to download.
+ENV ARCHIVE="snowplow_emr_${EMR_ETL_RUNNER_VERSION}.zip"
+
+# Install the Scala Stream Collector.
+RUN mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    wget -q http://dl.bintray.com/snowplow/snowplow-generic/${ARCHIVE} && \
+    unzip -d ${SNOWPLOW_BIN_PATH} ${ARCHIVE} && \
+    cd /tmp && \
+    rm -rf /tmp/build
+
+# Defines an entrypoint script delegating the lauching of stream enrich to the snowplow user.
+# The script uses dumb-init as the top-level process.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+
+CMD [ "--help" ]

--- a/emr-etl-runner/r109_lambaesis/docker-entrypoint.sh
+++ b/emr-etl-runner/r109_lambaesis/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/dumb-init /bin/sh
+set -e
+
+# If the config directory has been mounted through -v, we chown it.
+if [ "$(stat -c %u ${SNOWPLOW_CONFIG_PATH})" != "$(id -u snowplow)" ]; then
+  chown snowplow:snowplow ${SNOWPLOW_CONFIG_PATH}
+fi
+
+# Make sure we run the collector as the snowplow user
+exec gosu snowplow:snowplow ${SNOWPLOW_BIN_PATH}/snowplow-emr-etl-runner "$@"


### PR DESCRIPTION
Hi all,

thank for your amazing job on Snowplow.

I'm working on an implementation of the Snowplow Batch pipeline running on Amazon ECS and I needed the EmrEtlRunner Image in order to run it as a scheduled task.

I saw the [PR #14](https://github.com/snowplow/snowplow-docker/pull/14) but it seems old and not merged yet, moreover, [Issue #34](https://github.com/snowplow/snowplow-docker/issues/34) is still open. I'm not sure what you are planning to do.

I wrote Dockerfile and the run script by following the exact same structure of other images. The only difference is about the release version name. The naming scheme used on Bintray is quite different and I needed to adapt the script according.

I look forward to your feedback!