### PR TITLE
Add image for k8s-based dataflow job deployment 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - IMG=igluctl/0.6.0
   - IMG=piinguin-server/0.1.1
   - IMG=emr-etl-runner/r114_polonnaruwa
+  - IMG=k8s-dataflow/0.1.0
   global:
   # BINTRAY_SNOWPLOW_DOCKER_USER
   - secure: IcBMTopBAIzGlWNgS7dw0iNmvFhd2dgSn/Y1mt6hXnzLrr7SDryRuxPqemsCBLIlf4xtpgHvuOoo+7jYywtAOqyHQ+EOnR5eU8/28v+Z8zd/Djnw0Sv10RV5oMS6ejh9gGS4WDNPvf9M1sfP5p+0gA0p68dNeObLDT4TwpG2pdpeEuqQ3RMGCQc+tb3Q26K6aUPXeIgAHUyIEgHtzxxfgrGNwSmxdb6npsWTUttKpQkJudGRk17xXW67Dd0PKLWJkDpien/lbkLIBK8MlwaH03NMawGcTChgM2njcqElqz1b46wxl1ATcVV2T7A6YPYZxb012P8j/KUZ6MLhdDFNhmz/jIk6caEZ3x4AH2Q0qN8C9Hn70yMN8gAliBeUN4pjLpKnD8t5HgCE+90EufppcQRCfCJhSk9xmegTaikan3QZCN09vwSctIBu4AeWYqctql6bLhNWguakbRIyk9feogmxqbn2HSoFpRrAEqXXv9jFKJrKm2UNKuLbXCvyoYqjAhxTPn7OMAY30wqsVSUu5gSt1fO0Pd+5H8yq44Ul3jROgYKM5NlLWUY+u8qp6KKm2zXQ2LFlr8rzZ2ar5pI9zZiABDMnRRUdAXDTnpDw2HtBvngGXhyfr/irrzach0z/f5YwHL7WVf9Wu7MqoVpexdDqThNGip4ansIikrC57LE=
@@ -90,3 +91,9 @@ deploy:
   on:
     tags: true
     condition: '"$(.travis/is_release_tag.sh emr-etl-runner $TRAVIS_TAG)" == "" && $? == 0 && $IMG = base-alpine/0.2.0'
+- provider: script
+  script: ./.travis/deploy.sh k8s-dataflow $TRAVIS_TAG
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: '"$(.travis/is_release_tag.sh k8s-dataflow $TRAVIS_TAG)" == "" && $? == 0 && $IMG = base-debian/0.1.0'

--- a/k8s-dataflow/0.1.0/Dockerfile
+++ b/k8s-dataflow/0.1.0/Dockerfile
@@ -1,0 +1,19 @@
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+LABEL MAINTAINER="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
+
+RUN \
+  mkdir -p /var/lib/apt/lists/partial &&\
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&\
+  apt-get update &&\
+  apt-get install -y apt-transport-https ca-certificates wget gnupg &&\
+  wget -O - http://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - &&\
+  apt-get update &&\
+  apt-get install -y python google-cloud-sdk &&\
+  apt-get purge -y --auto-remove gnupg
+
+USER snowplow
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+
+CMD [ "" ]

--- a/k8s-dataflow/0.1.0/docker-entrypoint.sh
+++ b/k8s-dataflow/0.1.0/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+DELAY=3
+THRESHOLD=5
+BUCKET=""
+
+ITER=0
+PARAMS=""
+
+# extract params
+for opt in "$@"; do
+  case "$opt" in
+      --tempLocation=*)
+          BUCKET="${opt#*=}"
+          PARAMS="$PARAMS $opt"
+          shift
+          ;;
+      --gcsThreshold=*)
+          THRESHOLD="${opt#*=}"
+          shift
+          ;;
+      --gcsDelay*)
+          DELAY="${opt#*=}"
+          shift
+          ;;
+      *) # preserve positional arguments
+          PARAMS="$PARAMS $opt"
+          shift
+          ;;
+  esac
+done
+
+if [ -z "$BUCKET" ]; then
+    echo "Missing --tempLocation flag. Exiting."
+    exit 1
+fi
+
+echo "params: ${PARAMS} threshold: ${THRESHOLD} delay: ${DELAY}"
+
+# enable service account
+gcloud auth activate-service-account --key-file=/snowplow/config/credentials.json
+
+# wait for GCS bucket to be available
+while [ ! -z $(gsutil ls -b "${BUCKET}" | grep BucketNotFoundException) ]; do
+    if [ "$ITER" -le "$THRESHOLD" ]; then
+        echo "Bucket ${BUCKET} does not exist, retrying: ${ITER}"
+        sleep "${DELAY}"
+
+        ITER=$(( ITER+1 ))
+    else
+        echo "Bucket ${BUCKET} does not exist. Not retrying anymore."
+        exit 1
+    fi
+done
+
+echo "Bucket ${BUCKET} exists. Proceeding."
+$PARAMS


### PR DESCRIPTION
The GCS loader needs to be deployed via k8s as there are significant limitations
on how Scio behaves on Dataflow (mostly optional parameter handling).
The kind of deployment has been a problem before. As the terraform resources are
created asynchronously the jobs would fail for missing temporary buckets that
are required to start. Therefore we need some sort of backoff strategy that will
delay the deployment for a couple of seconds before the actual deployment trigger happens.
We need this image before we make amendments to the loader build itself that needs to be in release 0.3.0 (see: https://github.com/snowplow-incubator/snowplow-google-cloud-storage-loader/blob/40d0cf387758d29d65f0c6eb7413eb80f83b2bad/build.sbt#L47)

<!--
Thank you for contributing to Snowplow Docker!

You'll find a small checklist below which should help speed up the review processs:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow/snowplow-docker/blob/master/CONTRIBUTING.md)?
- [ ] Is your pull request against the `develop` branch?
-->

