### PR TITLE
Upgrade base image of service dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Alternatively, you can build them yourself:
 
 ```bash
 # All images are based on the base images
-docker pull snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
-docker pull snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+docker pull snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
+docker pull snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 
 # NSQ Scala Stream Collector image, there are others available for Kinesis, Kafka and Google PubSub
 docker build -t snowplow/scala-stream-collector-nsq:0.15.0 scala-stream-collector/0.15.0/nsq

--- a/elasticsearch-loader/0.10.2/Dockerfile
+++ b/elasticsearch-loader/0.10.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the loader to download.

--- a/emr-etl-runner/r109_lambaesis/Dockerfile
+++ b/emr-etl-runner/r109_lambaesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of EmrEtlRunner to download.

--- a/emr-etl-runner/r112_baalbek/Dockerfile
+++ b/emr-etl-runner/r112_baalbek/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of EmrEtlRunner to download.

--- a/emr-etl-runner/r113_filitosa/Dockerfile
+++ b/emr-etl-runner/r113_filitosa/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of EmrEtlRunner to download.

--- a/emr-etl-runner/r114_polonnaruwa/Dockerfile
+++ b/emr-etl-runner/r114_polonnaruwa/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of EmrEtlRunner to download.

--- a/iglu-server/0.4.0/Dockerfile
+++ b/iglu-server/0.4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the server to download

--- a/igluctl/0.5.0/Dockerfile
+++ b/igluctl/0.5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # Bin path

--- a/igluctl/0.6.0/Dockerfile
+++ b/igluctl/0.6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # Bin path

--- a/k8s-dataflow/0.1.1/Dockerfile
+++ b/k8s-dataflow/0.1.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL MAINTAINER="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 RUN \

--- a/k8s-dataflow/0.2.0/Dockerfile
+++ b/k8s-dataflow/0.2.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL MAINTAINER="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 RUN \

--- a/piinguin-server/0.1.1/Dockerfile
+++ b/piinguin-server/0.1.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the server to download

--- a/scala-stream-collector/0.13.0/google-pubsub/Dockerfile
+++ b/scala-stream-collector/0.13.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.14.0/google-pubsub/Dockerfile
+++ b/scala-stream-collector/0.14.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.14.0/kafka/Dockerfile
+++ b/scala-stream-collector/0.14.0/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.14.0/kinesis/Dockerfile
+++ b/scala-stream-collector/0.14.0/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.14.0/nsq/Dockerfile
+++ b/scala-stream-collector/0.14.0/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.15.0/google-pubsub/Dockerfile
+++ b/scala-stream-collector/0.15.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.15.0/kafka/Dockerfile
+++ b/scala-stream-collector/0.15.0/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.15.0/kinesis/Dockerfile
+++ b/scala-stream-collector/0.15.0/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/scala-stream-collector/0.15.0/nsq/Dockerfile
+++ b/scala-stream-collector/0.15.0/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of the collector to download.

--- a/stream-enrich/0.15.0/google-pubsub/Dockerfile
+++ b/stream-enrich/0.15.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.16.0/google-pubsub/Dockerfile
+++ b/stream-enrich/0.16.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.16.1/google-pubsub/Dockerfile
+++ b/stream-enrich/0.16.1/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.17.0/google-pubsub/Dockerfile
+++ b/stream-enrich/0.17.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.18.0/google-pubsub/Dockerfile
+++ b/stream-enrich/0.18.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.18.0/kafka/Dockerfile
+++ b/stream-enrich/0.18.0/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.18.0/kinesis/Dockerfile
+++ b/stream-enrich/0.18.0/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.18.0/nsq/Dockerfile
+++ b/stream-enrich/0.18.0/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.0/google-pubsub/Dockerfile
+++ b/stream-enrich/0.19.0/google-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-debian:0.1.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.0/kafka/Dockerfile
+++ b/stream-enrich/0.19.0/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.0/kinesis/Dockerfile
+++ b/stream-enrich/0.19.0/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.0/nsq/Dockerfile
+++ b/stream-enrich/0.19.0/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.1/kafka/Dockerfile
+++ b/stream-enrich/0.19.1/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.1/kinesis/Dockerfile
+++ b/stream-enrich/0.19.1/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.19.1/nsq/Dockerfile
+++ b/stream-enrich/0.19.1/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.20.0/kafka/Dockerfile
+++ b/stream-enrich/0.20.0/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.20.0/kinesis/Dockerfile
+++ b/stream-enrich/0.20.0/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.20.0/nsq/Dockerfile
+++ b/stream-enrich/0.20.0/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.21.0/kafka/Dockerfile
+++ b/stream-enrich/0.21.0/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.21.0/kinesis/Dockerfile
+++ b/stream-enrich/0.21.0/kinesis/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.

--- a/stream-enrich/0.21.0/nsq/Dockerfile
+++ b/stream-enrich/0.21.0/nsq/Dockerfile
@@ -1,4 +1,4 @@
-FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.0
+FROM snowplow-docker-registry.bintray.io/snowplow/base-alpine:0.2.1
 LABEL maintainer="Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
 
 # The version of stream enrich to download.


### PR DESCRIPTION
This pull request aims to pass the newly released base images on to the service dockerfiles. This hopefully helps to fix the reported vulnerabilities by the AWS container scan.